### PR TITLE
pom-s for clean deploys

### DIFF
--- a/nest-bootstrap/pom.xml
+++ b/nest-bootstrap/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>nest</artifactId>
         <groupId>org.esa.nest</groupId>
-        <version>${nest.version}</version>
+        <version>4B-1.1</version>
     </parent>
 
     <packaging>jar</packaging>
@@ -16,7 +16,6 @@
     <artifactId>nest-bootstrap</artifactId>
     <name>NEST Bootstrap Classpath</name>
     <description>Provides the bootstrap classpath to launch DAT from your favourite IDE.</description>
-    <version>${nest.version}</version>
 
     <dependencies>
         <dependency>

--- a/nest-core/pom.xml
+++ b/nest-core/pom.xml
@@ -7,13 +7,12 @@
     <parent>
         <groupId>org.esa.nest</groupId>
         <artifactId>nest</artifactId>
-        <version>${nest.version}</version>
+        <version>4B-1.1</version>
     </parent>
 
     <name>NEST Core</name>
     <groupId>org.esa.nest</groupId>
     <artifactId>nest-core</artifactId>
-    <version>${nest.version}</version>
 
     <packaging>jar</packaging>
 

--- a/nest-dat/pom.xml
+++ b/nest-dat/pom.xml
@@ -8,13 +8,12 @@
     <parent>
         <groupId>org.esa.nest</groupId>
         <artifactId>nest</artifactId>
-        <version>${nest.version}</version>
+        <version>4B-1.1</version>
     </parent>
 
     <name>NEST Display and Analysis Tool</name>
     <groupId>org.esa.nest</groupId>
     <artifactId>nest-dat</artifactId>
-    <version>${nest.version}</version>
 
     <packaging>jar</packaging>
 

--- a/nest-developer-tools/maven-nest-dataio-archetype/pom.xml
+++ b/nest-developer-tools/maven-nest-dataio-archetype/pom.xml
@@ -5,13 +5,12 @@
 	<parent>
         <groupId>org.esa.nest</groupId>
         <artifactId>nest</artifactId>
-        <version>${nest.version}</version>
+        <version>4B-1.1</version>
 		<relativePath>../../pom.xml</relativePath>
     </parent>
 	
     <groupId>org.esa.nest.maven</groupId>
     <artifactId>maven-nest-dataio-archetype</artifactId>
-    <version>${nest.version}</version>
     <name>Maven 2 NEST Data I/O Archetype Plugin</name>
     <description>A Maven 2 archetype for projects using NEST Data I/O framework.</description>
     <packaging>jar</packaging>

--- a/nest-developer-tools/maven-nest-gpf-archetype/pom.xml
+++ b/nest-developer-tools/maven-nest-gpf-archetype/pom.xml
@@ -5,13 +5,12 @@
 	<parent>
         <groupId>org.esa.nest</groupId>
         <artifactId>nest</artifactId>
-        <version>${nest.version}</version>
+        <version>4B-1.1</version>
 		<relativePath>../../pom.xml</relativePath>
     </parent>
 	
     <groupId>org.esa.nest.maven</groupId>
     <artifactId>maven-nest-gpf-archetype</artifactId>
-    <version>${nest.version}</version>
     <name>Maven 2 Archetype Plugin for NEST GPF Operators</name>
     <description>A Maven 2 archetype for projects using NEST Graph Processing Framework (GPF).</description>
     <packaging>jar</packaging>

--- a/nest-graph-builder/pom.xml
+++ b/nest-graph-builder/pom.xml
@@ -7,13 +7,12 @@
     <parent>
         <groupId>org.esa.nest</groupId>
         <artifactId>nest</artifactId>
-        <version>${nest.version}</version>
+        <version>4B-1.1</version>
     </parent>
 
     <name>NEST Graph Builder</name>
     <groupId>org.esa.nest</groupId>
     <artifactId>nest-graph-builder</artifactId>
-    <version>${nest.version}</version>
 
     <packaging>jar</packaging>
 

--- a/nest-help/pom.xml
+++ b/nest-help/pom.xml
@@ -7,14 +7,13 @@
     <parent>
         <groupId>org.esa.nest</groupId>
         <artifactId>nest</artifactId>
-        <version>${nest.version}</version>
+        <version>4B-1.1</version>
     </parent>
 
     <groupId>org.esa.nest</groupId>
     <artifactId>nest-help</artifactId>
     <name>NEST Help</name>
     <description>Provides the software user manual.</description>
-    <version>${nest.version}</version>
 
     <build>
         <plugins>

--- a/nest-io/pom.xml
+++ b/nest-io/pom.xml
@@ -6,13 +6,12 @@
     <parent>
         <groupId>org.esa.nest</groupId>
         <artifactId>nest</artifactId>
-        <version>${nest.version}</version>
+        <version>4B-1.1</version>
     </parent>
 
     <groupId>org.esa.nest</groupId>
     <artifactId>nest-io</artifactId>
     <name>NEST Readers and Writers</name>
-    <version>${nest.version}</version>
 
     <packaging>jar</packaging>
 

--- a/nest-ocean-tools/pom.xml
+++ b/nest-ocean-tools/pom.xml
@@ -2,14 +2,13 @@
   <parent>
     <artifactId>nest</artifactId>
     <groupId>org.esa.nest</groupId>
-    <version>${nest.version}</version>
+    <version>4B-1.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   
   <groupId>org.esa.nest</groupId>
   <artifactId>nest-ocean-tools</artifactId>
   <name>NEST Ocean Tools</name>
-  <version>${nest.version}</version>
   <description>Provides operators for ocean SAR applications</description>
   
   <dependencies>

--- a/nest-op-calibration/pom.xml
+++ b/nest-op-calibration/pom.xml
@@ -2,14 +2,13 @@
   <parent>
     <artifactId>nest</artifactId>
     <groupId>org.esa.nest</groupId>
-	<version>${nest.version}</version>
+	<version>4B-1.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   
   <groupId>org.esa.nest</groupId>
   <artifactId>nest-op-calibration</artifactId>
   <name>NEST Calibration Operator</name>
-  <version>${nest.version}</version>
   <description>Calibrates ENVISAT ASAR, ERS 1/2, ALOS Palsar products</description>
   
   <dependencies>

--- a/nest-op-coregistration/pom.xml
+++ b/nest-op-coregistration/pom.xml
@@ -1,58 +1,58 @@
-<?xml version="1.0"?><project>
-  <parent>
-    <artifactId>nest</artifactId>
+<?xml version="1.0"?>
+<project>
+    <parent>
+        <artifactId>nest</artifactId>
+        <groupId>org.esa.nest</groupId>
+        <version>4B-1.1</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
     <groupId>org.esa.nest</groupId>
-    <version>${nest.version}</version>
-  </parent>
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>org.esa.nest</groupId>
-  <artifactId>nest-op-coregistration</artifactId>
-  <name>NEST Coregistration</name>
-  <version>${nest.version}</version>
-  <description>GCP Selection and Warping</description>
+    <artifactId>nest-op-coregistration</artifactId>
+    <name>NEST Coregistration</name>
+    <description>GCP Selection and Warping</description>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.beam</groupId>
-      <artifactId>beam-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.beam</groupId>
-      <artifactId>beam-gpf</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.nest</groupId>
-      <artifactId>nest-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.nest</groupId>
-      <artifactId>nest-graph-builder</artifactId>
-    </dependency>
-	<dependency>
-      <groupId>edu.emory.mathcs</groupId>
-      <artifactId>jtransforms</artifactId>
-    </dependency>
+    <dependencies>
         <dependency>
-      <groupId>org.esa.beam</groupId>
-      <artifactId>beam-envisat-reader</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.nest</groupId>
-      <artifactId>nest-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.nest</groupId>
-      <artifactId>nest-reader-dem</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>org</groupId>
-        <artifactId>jblas</artifactId>
-    </dependency>
-  </dependencies>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.beam</groupId>
+            <artifactId>beam-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.beam</groupId>
+            <artifactId>beam-gpf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.nest</groupId>
+            <artifactId>nest-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.nest</groupId>
+            <artifactId>nest-graph-builder</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>edu.emory.mathcs</groupId>
+            <artifactId>jtransforms</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.beam</groupId>
+            <artifactId>beam-envisat-reader</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.nest</groupId>
+            <artifactId>nest-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.nest</groupId>
+            <artifactId>nest-reader-dem</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org</groupId>
+            <artifactId>jblas</artifactId>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>

--- a/nest-op-orthorectification/pom.xml
+++ b/nest-op-orthorectification/pom.xml
@@ -1,62 +1,62 @@
-<?xml version="1.0"?><project>
-  <parent>
-    <artifactId>nest</artifactId>
+<?xml version="1.0"?>
+<project>
+    <parent>
+        <artifactId>nest</artifactId>
+        <groupId>org.esa.nest</groupId>
+        <version>4B-1.1</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
     <groupId>org.esa.nest</groupId>
-    <version>${nest.version}</version>
-  </parent>
-  <modelVersion>4.0.0</modelVersion>
-  
-  <groupId>org.esa.nest</groupId>
-  <artifactId>nest-op-orthorectification</artifactId>
-  <name>NEST Orthorectification</name>
-  <version>${nest.version}</version>
-  <description>Provides for orthorectifying SAR data</description>
-  
-  <dependencies>
-    <dependency>
-      <groupId>org.esa.beam</groupId>
-      <artifactId>beam-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.beam</groupId>
-      <artifactId>beam-gpf</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.beam</groupId>
-      <artifactId>beam-visat-rcp</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.nest</groupId>
-      <artifactId>nest-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.nest</groupId>
-      <artifactId>nest-graph-builder</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.nest</groupId>
-      <artifactId>nest-op-calibration</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.nest</groupId>
-      <artifactId>nest-op-coregistration</artifactId>
-	  <version>${nest.version}</version>
-    </dependency>
+    <artifactId>nest-op-orthorectification</artifactId>
+    <name>NEST Orthorectification</name>
+    <description>Provides for orthorectifying SAR data</description>
+
+    <dependencies>
         <dependency>
-      <groupId>org.esa.beam</groupId>
-      <artifactId>beam-envisat-reader</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.nest</groupId>
-      <artifactId>nest-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.esa.nest</groupId>
-      <artifactId>nest-reader-dem</artifactId>
-    </dependency>
-  </dependencies>
-  
-	<build>
+            <groupId>org.esa.beam</groupId>
+            <artifactId>beam-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.beam</groupId>
+            <artifactId>beam-gpf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.beam</groupId>
+            <artifactId>beam-visat-rcp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.nest</groupId>
+            <artifactId>nest-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.nest</groupId>
+            <artifactId>nest-graph-builder</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.nest</groupId>
+            <artifactId>nest-op-calibration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.nest</groupId>
+            <artifactId>nest-op-coregistration</artifactId>
+            <version>${nest.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.beam</groupId>
+            <artifactId>beam-envisat-reader</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.nest</groupId>
+            <artifactId>nest-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.esa.nest</groupId>
+            <artifactId>nest-reader-dem</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
         <plugins>
             <plugin>
                 <groupId>com.bc.maven.plugins</groupId>

--- a/nest-op-sar-tools/pom.xml
+++ b/nest-op-sar-tools/pom.xml
@@ -2,14 +2,13 @@
   <parent>
     <artifactId>nest</artifactId>
     <groupId>org.esa.nest</groupId>
-    <version>${nest.version}</version>
+    <version>4B-1.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   
   <groupId>org.esa.nest</groupId>
   <artifactId>nest-op-sar-tools</artifactId>
   <name>NEST SAR Tools</name>
-  <version>${nest.version}</version>
   <description>Provides various operators for processing on SAR data</description>
   
   <dependencies>

--- a/nest-reader-dem/pom.xml
+++ b/nest-reader-dem/pom.xml
@@ -6,14 +6,13 @@
     <parent>
         <artifactId>nest</artifactId>
         <groupId>org.esa.nest</groupId>
-        <version>${nest.version}</version>
+        <version>4B-1.1</version>
     </parent>
 
     <groupId>org.esa.nest</groupId>
     <artifactId>nest-reader-dem</artifactId>
     <name>NEST DEM Reader</name>
-    <version>${nest.version}</version>
-	
+
     <packaging>jar</packaging>
 
     <dependencies>

--- a/nest-src/pom.xml
+++ b/nest-src/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>nest</artifactId>
         <groupId>org.esa.nest</groupId>
-        <version>${nest.version}</version>
+        <version>4B-1.1</version>
     </parent>
 
     <packaging>jar</packaging>
@@ -16,7 +16,6 @@
     <artifactId>nest-src</artifactId>
     <name>NEST src</name>
     <description>Adds the resources for the runtime environment.</description>
-    <version>${nest.version}</version>
 
 	<profiles>
 	  <profile>

--- a/nest-world-wind-view/pom.xml
+++ b/nest-world-wind-view/pom.xml
@@ -3,14 +3,13 @@
     <parent>
         <groupId>org.esa.nest</groupId>
         <artifactId>nest</artifactId>
-        <version>${nest.version}</version>
+        <version>4B-1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <name>NEST World Wind View</name>
     <groupId>org.esa.nest</groupId>
     <artifactId>nest-world-wind-view</artifactId>
-    <version>${nest.version}</version>
 
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-	
-	<properties>
+
+    <name>NEST Project</name>
+    <url>http://www.array.ca/nest</url>
+    <groupId>org.esa.nest</groupId>
+    <artifactId>nest</artifactId>
+    <version>4B-1.1</version>
+
+    <properties>
         <!--
 	           In version 3.0 of Maven the sourceEncoding property will be embedded in the
 	           build tag. For now the convention is to that it as property.
@@ -22,12 +28,6 @@
 		<jdoris.version>0.2</jdoris.version>
 		<outputdir>../output</outputdir>
     </properties>
-	
-    <name>NEST Project</name>
-    <url>http://www.array.ca/nest</url>
-    <groupId>org.esa.nest</groupId>
-    <artifactId>nest</artifactId>
-    <version>${nest.version}</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Fix for ticket #516 (https://www.array.ca/nest/trac/ticket/516): NEST poms do not perform clean deploy

....for version less parents we have to wait for Maven 3.1.
