### PR TITLE
Fix for correct index handling of ASTER DEM

### DIFF
--- a/nest-reader-dem/src/main/java/org/esa/nest/dataio/dem/aster/AsterElevationModel.java
+++ b/nest-reader-dem/src/main/java/org/esa/nest/dataio/dem/aster/AsterElevationModel.java
@@ -103,7 +103,7 @@ public final class AsterElevationModel implements ElevationModel, Resampling.Ras
     @Override
     public synchronized GeoPos getGeoPos(PixelPos pixelPos) throws Exception {
         float pixelLat = (RASTER_HEIGHT - pixelPos.y) / DEGREE_RES_BY_NUM_PIXELS_PER_TILE - 83.0f;
-        float pixelLon = pixelPos.x / DEGREE_RES_BY_NUM_PIXELS_PER_TILE - 180.0f;
+        float pixelLon = pixelPos.x * DEGREE_RES_BY_NUM_PIXELS_PER_TILE - 180.0f;
         return new GeoPos(pixelLat, pixelLon);
     }
 


### PR DESCRIPTION
Small bug in getGeoPos method: now conversion from DEM index to corresponding Geo position should work okay.

/p
