### PR TITLE
NEST 4C InSAR update: smarter tile handling in spectral filtering operators, and minor optimization.

### DIFF
--- a/jdoris/jdoris-core/src/main/java/org/jdoris/core/utils/PolyUtils.java
+++ b/jdoris/jdoris-core/src/main/java/org/jdoris/core/utils/PolyUtils.java
@@ -222,9 +222,11 @@ public class PolyUtils {
             logger.warn("polyValGrid: degree < -1 ????");
         }
 
+/*
         if (x.length > y.length) {
             logger.warn("polValGrid: x larger than y, while optimized for y larger x");
         }
+*/
 
         if (degree == -1) {
             degree = degreeFromCoefficients(coeff.length);
@@ -463,9 +465,11 @@ public class PolyUtils {
             logger.warn("polyValGrid: degree < -1 ????");
         }
 
+/*
         if (x.length > y.length) {
             logger.warn("polValGrid: x larger than y, while optimized for y larger x");
         }
+*/
 
         if (degree == -1) {
             degree = degreeFromCoefficients(coeff.length);

--- a/jdoris/jdoris-nest/src/main/java/org/jdoris/nest/gpf/SubtRefDemOp.java
+++ b/jdoris/jdoris-nest/src/main/java/org/jdoris/nest/gpf/SubtRefDemOp.java
@@ -465,9 +465,12 @@ public final class SubtRefDemOp extends Operator {
         // double square root : scales with the size of tile
         final int numberOfPoints = (int) (10 * Math.sqrt(Math.sqrt(rectangle.width * rectangle.height)));
 
-        // work with 1.5x size of tile
-        int offsetX = (int) (1.5 * rectangle.width);
-        int offsetY = (int) (1.5 * rectangle.height);
+        System.out.println("numberOfPoints = " + numberOfPoints);
+
+        // work with 1.75x size of tile
+        double extendTimes = 1.75;
+        int offsetX = (int) (extendTimes * rectangle.width);
+        int offsetY = (int) (extendTimes * rectangle.height);
 
         // define window
         final Window window = new Window((long) (corners[0].y - offsetY), (long) (corners[1].y + offsetY),
@@ -485,10 +488,11 @@ public final class SubtRefDemOp extends Operator {
             }
         }
 
-        // get max/min and add extra 25% to max height ~ just to be sure
+        // get max/min and add extra 30% to max height ~ just to be sure
         if (heights.size() > 2) {
-            heightArray[0] = Collections.min(heights);
-            heightArray[1] = Collections.max(heights) * 1.25;
+            heightArray[0] = Collections.min(heights) * 0.70;
+//            heightArray[1] = Collections.max(heights) * 1.25;
+            heightArray[1] = Collections.max(heights) * 1.30;
         } else { // if nodatavalues return 0s ~ tile in the sea
             heightArray[0] = 0;
             heightArray[1] = 0;

--- a/jdoris/jdoris-nest/src/main/java/org/jdoris/nest/utils/TileUtilsDoris.java
+++ b/jdoris/jdoris-nest/src/main/java/org/jdoris/nest/utils/TileUtilsDoris.java
@@ -104,6 +104,32 @@ public class TileUtilsDoris {
         tile.setRawSamples(samples); // commit
     }
 
+    public static void pushFloatMatrix(FloatMatrix data, Tile tile, Rectangle rect, int y0, int x0) {
+
+        final ProductData samples = tile.getRawSamples(); // checkout
+        final int width = (int) rect.getWidth();
+
+        for (int y = 0, rowIdx = y0; y < rect.getHeight(); y++, rowIdx++) {
+            for (int x = 0, columnIdx = x0; x < rect.getWidth(); x++, columnIdx++) {
+                samples.setElemDoubleAt(y * width + x, data.get(rowIdx, columnIdx));
+            }
+        }
+        tile.setRawSamples(samples); // commit
+    }
+
+    public static void pushFloatMatrix(DoubleMatrix data, Tile tile, Rectangle rect, int y0, int x0) {
+
+        final ProductData samples = tile.getRawSamples(); // checkout
+        final int width = (int) rect.getWidth();
+
+        for (int y = 0, rowIdx = y0; y < rect.getHeight(); y++, rowIdx++) {
+            for (int x = 0, columnIdx = x0; x < rect.getWidth(); x++, columnIdx++) {
+                samples.setElemDoubleAt(y * width + x, data.get(rowIdx, columnIdx));
+            }
+        }
+        tile.setRawSamples(samples); // commit
+    }
+
     public static void pushDoubleArray2D(double[][] data, Tile tile, Rectangle rect) {
 
         final ProductData samples = tile.getRawSamples(); // checkout


### PR DESCRIPTION
Spectral Filters: Even though reported issues with spectral filters are not the real bugs - issues with tiling effects being present in differential results (filtered wrt not.filtered data) : I decided to address them, and to optimize and clean-up these operators. They should be much smarter in handling tile overlaps now, and there should be no significant performance penalty if working with not "power of 2" tile sizes. 

Delaunay Interpolation & Subtraction of the reference DEM phase: optimization in how the extra size for input tiles is computed. It's quick&dirty but good enough.
