### PR TITLE
Fix for correct handling of ASTER in InSAR modules and for Delaunay interpolation

### DIFF
--- a/nest-reader-dem/src/main/java/org/esa/nest/dataio/dem/aster/AsterElevationModel.java
+++ b/nest-reader-dem/src/main/java/org/esa/nest/dataio/dem/aster/AsterElevationModel.java
@@ -41,17 +41,17 @@ public final class AsterElevationModel extends BaseElevationModel {
 
     @Override
     public double getIndexX(final GeoPos geoPos) {
-        return ((geoPos.lon + 180.0) / DEGREE_RES_BY_NUM_PIXELS_PER_TILE);
+        return (geoPos.lon + 180.0) * DEGREE_RES_BY_NUM_PIXELS_PER_TILEinv;
     }
 
     @Override
     public double getIndexY(final GeoPos geoPos) {
-        return (RASTER_HEIGHT - (geoPos.lat + 83.0) / DEGREE_RES_BY_NUM_PIXELS_PER_TILE);
+        return (83.0 - geoPos.lat) * DEGREE_RES_BY_NUM_PIXELS_PER_TILEinv;
     }
 
     @Override
     public GeoPos getGeoPos(final PixelPos pixelPos) {
-        final double pixelLat = (RASTER_HEIGHT - pixelPos.y) / DEGREE_RES_BY_NUM_PIXELS_PER_TILE - 83.0;
+        final double pixelLat = (RASTER_HEIGHT - pixelPos.y) * DEGREE_RES_BY_NUM_PIXELS_PER_TILE - 83.0;
         final double pixelLon = pixelPos.x * DEGREE_RES_BY_NUM_PIXELS_PER_TILE - 180.0;
         return new GeoPos((float)pixelLat, (float)pixelLon);
     }


### PR DESCRIPTION
Luis, here's the fix for correct ASTER handling - summary below. Please have a look. 

The issue for InSAR and Delaunay was  that I am using getGeoPos to define the interpolation space, and compute interpolation extent. This getGeoPos call was returning completely wrong values (was dividing instead of multiplying!), and when converting geo to radar coordinates something would shoot-off to infinity, and hence the reported error "radians only" would get triggered.

All InSAR tests pass now. I haven't tested non-InSAR Delaunay interpolation since it is skipped for this release.

---

Fix for getGeoPos() of AsterElevationModel

AsterElevationModel.getGeoPos() now correctly computes Geographic
coordinates as a function of pixel index for ASTER DEM. This bug was
effecting correct use of ASTER DEM in InSAR modules, and modules
using Delaunay interpolation.

All InSAR tests passing.
