### PR TITLE
fix for clean build

### DIFF
--- a/nest-developer-tools/maven-nest-gpf-archetype/pom.xml
+++ b/nest-developer-tools/maven-nest-gpf-archetype/pom.xml
@@ -38,7 +38,8 @@
         <dependency>
             <groupId>org.esa.beam</groupId>
             <artifactId>beam-gpf</artifactId>
-            <version>${beam.version}</version>
+            <!-- <version>${beam.version}</version> -->
+            <version>5.0.1-4.10.4</version>
         </dependency>
 
 		<dependency>

--- a/nest-developer-tools/maven-nest-gpf-archetype/pom.xml
+++ b/nest-developer-tools/maven-nest-gpf-archetype/pom.xml
@@ -60,8 +60,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <debug>true</debug>
                     <fork>false</fork>
                     <encoding>ISO-8859-1</encoding>


### PR DESCRIPTION
pom.xml of gpf-archetype has to be updated with the latest version of beam-gpf. Otherwise the clean build is failing. I reckon you'll be synchronizing version numbers soon anyhow.

Btw, you are not mvn deploy-ing anymore?
