### PR TITLE
jLinda tracked as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,3 @@ target/
 CVS/
 .cvsignore
 .svn
-jlinda
-jlinda/
-.gitmodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jlinda"]
+	path = jlinda
+	url = git@bitbucket.org:pmar/jlinda.git


### PR DESCRIPTION
Tracking of jLinda as submodule, fix for correct submodule tracking. 

Sorry I forgot to include this one in yesterdays pull request. To have 'pristine' config for submodule and remove some dev settings, I fist removed submodule, and the add jLinda as submodule again. Still I pushed changes to github without this re-submode.
