### PR TITLE
Recommiting jLinda as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "jlinda"]
 	path = jlinda
-	url = git@bitbucket.org:pmar/jlinda.git
+	url = git@github.com:ppolabs/jlinda.git


### PR DESCRIPTION
Please merge-in this pull request. I ended up having quite some problems and conflicts between different versions of git, and how they handle submodules ([resource](http://git.661346.n2.nabble.com/BUG-Fail-to-add-a-module-in-a-subdirectory-if-module-is-already-cloned-td7221426.html)). The simplest way to resolve, was to remove and commit again jlinda as the submodule. Sorry about this redundancy.
