### PR TITLE
Update of plugin versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -686,7 +686,7 @@
                 <artifactId>jcommon</artifactId>
                 <version>1.0.17</version>
             </dependency>
-			
+
 			<!-- Python scripting support ######################################## -->
 
             <dependency>
@@ -694,15 +694,15 @@
                 <artifactId>jython</artifactId>
                 <version>2.5.2</version>
             </dependency>
-			
+
 			<!-- Apache Derby -->
-			
+
 			<dependency>
 				<groupId>org.apache.derby</groupId>
 				<artifactId>derby</artifactId>
 				<version>10.10.1.1</version>
 			</dependency>
-			
+
 			<dependency>
 	            <groupId>commons-net</groupId>
 	            <artifactId>commons-net</artifactId>
@@ -789,7 +789,7 @@
 	        <plugins>
 	            <plugin>
 	                <artifactId>maven-compiler-plugin</artifactId>
-					<version>2.5.1</version>
+					<version>3.1</version>
 	                <configuration>
 	                    <source>1.7</source>
 	                    <target>1.7</target>
@@ -801,7 +801,7 @@
 				
 				<plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.2-beta-1</version>
+                    <version>2.4</version>
                 </plugin>
 
                 <plugin>
@@ -837,7 +837,7 @@
 				<plugin>
 	                <groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.9</version>
+					<version>2.9.1</version>
 					<configuration>
 						<aggregate>true</aggregate>
 						<maxmemory>600m</maxmemory>
@@ -853,7 +853,7 @@
 				
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-					<version>2.12.4</version>
+					<version>2.16</version>
                     <configuration>
 						<!--  to test from the command line mvn test -DskipTests=false -->
                         <skipTests>${skipTests}</skipTests>
@@ -878,7 +878,7 @@
 
                 <plugin>
                     <artifactId>maven-idea-plugin</artifactId>
-					<version>2.2</version>
+					<version>2.2.1</version>
                     <configuration>
                         <downloadSources>true</downloadSources>
                         <downloadJavadocs>true</downloadJavadocs>
@@ -896,7 +896,7 @@
 				<plugin>
 			        <groupId>org.codehaus.mojo</groupId>
 			        <artifactId>versions-maven-plugin</artifactId>
-			        <version>1.3-SNAPSHOT</version>
+			        <version>2.1</version>
 			     </plugin>
 			  
 				<plugin>
@@ -919,7 +919,7 @@
 			   <plugin>
 				  <groupId>org.apache.maven.plugins</groupId>
 				  <artifactId>maven-project-info-reports-plugin</artifactId>
-				  <version>2.6</version>
+				  <version>2.7</version>
 				</plugin>
             </plugins>
         </pluginManagement>
@@ -974,7 +974,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
-				<version>3.0-beta-3</version>
+				<version>3.3</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -1000,7 +1000,6 @@
 				  </executions>
 			</plugin>
         </plugins>
-		
     </build>
 
     <reporting>
@@ -1008,7 +1007,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.9</version>
+				<version>2.9.1</version>
 				<configuration>
 					<aggregate>true</aggregate>
 					<maxmemory>600m</maxmemory>


### PR DESCRIPTION
Update of plugin versions in central pom of NEST.

Notes:
- versions of assembly and compiler plugin would brake the build process, and cause problems in packaging with the latest maven 3.1.1 and jdk 1.7.0_45.
- tested compiling and assembling with this pom on linux64 and win64.
- other plugin versions I do not think are critical, still I updated their versions.
