### PR TITLE
Removed maven-idea-plugin from project poms.

### DIFF
--- a/beam/pom.xml
+++ b/beam/pom.xml
@@ -804,18 +804,6 @@
                 </plugin>
 
                 <plugin>
-                    <artifactId>maven-idea-plugin</artifactId>
-                    <version>2.2</version>
-                    <configuration>
-                        <downloadSources>true</downloadSources>
-                        <downloadJavadocs>true</downloadJavadocs>
-                        <jdkName>1.6</jdkName>
-                        <jdkLevel>1.6</jdkLevel>
-                        <exclude>target</exclude>
-                    </configuration>
-                </plugin>
-
-                <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
                     <version>2.5</version>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -876,18 +876,6 @@
                     
                 </plugin>
 
-                <plugin>
-                    <artifactId>maven-idea-plugin</artifactId>
-					<version>2.2.1</version>
-                    <configuration>
-                        <downloadSources>true</downloadSources>
-                        <downloadJavadocs>true</downloadJavadocs>
-                        <jdkName>1.7</jdkName>
-                        <jdkLevel>1.7</jdkLevel>
-                        <exclude>target</exclude>
-						<!--<useShortDependencyNames>true</useShortDependencyNames>-->
-                    </configuration>
-                </plugin>
 				<plugin>
                     <artifactId>maven-clean-plugin</artifactId>
 					<version>2.5</version>


### PR DESCRIPTION
I leave merge of this one up to you.

---

Maven's idea plugin is retired, and triggers errors with recent
versions of maven (v3.1.1) on linux. See discussion of this pull
request https://github.com/lveci/nest/pull/27 for more details.
